### PR TITLE
templatefunctions: Add optional parameter to stripTags() template function

### DIFF
--- a/pugjs/pug_parser.go
+++ b/pugjs/pug_parser.go
@@ -149,7 +149,8 @@ func (p *renderState) build(parent *Token) (res []Node) {
 	return
 }
 
-var selfclosing = map[string]bool{
+// SelfClosingTags contains all self closing HTML tags
+var SelfClosingTags = map[string]bool{
 	"area":    true,
 	"base":    true,
 	"br":      true,
@@ -183,7 +184,7 @@ func (p *renderState) buildNode(t *Token) (res Node) {
 			tag.Attrs = append(tag.Attrs, Attribute{Name: a.Name, Val: JavaScriptExpression(fmt.Sprintf("%v", a.Val)), MustEscape: a.MustEscape})
 		}
 
-		tag.SelfClosing = selfclosing[tag.Name]
+		tag.SelfClosing = SelfClosingTags[tag.Name]
 
 		return tag
 
@@ -290,7 +291,7 @@ func (p *renderState) buildNode(t *Token) (res Node) {
 		}
 
 		// todo how?
-		// interpolatedTag.SelfClosing = selfclosing[interpolatedTag.Name]
+		// interpolatedTag.SelfClosing = SelfClosingTags[interpolatedTag.Name]
 
 		return interpolatedTag
 

--- a/templatefunctions/striptags_func.go
+++ b/templatefunctions/striptags_func.go
@@ -115,7 +115,11 @@ func getAllowedAttributes(attributes []html.Attribute, allowedAttributes allowed
 	res := ""
 	for _, attr := range attributes {
 		if _, ok := allowedAttributes[attr.Key]; ok {
-			res += " " + attr.Key + "=\"" + html.EscapeString(attr.Val) + "\""
+			if attr.Val != "" {
+				res += " " + attr.Key + "=\"" + html.EscapeString(attr.Val) + "\""
+			} else {
+				res += " " + attr.Key
+			}
 		}
 	}
 	return res

--- a/templatefunctions/striptags_func.go
+++ b/templatefunctions/striptags_func.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"flamingo.me/flamingo/v3/framework/config"
+	"flamingo.me/pugtemplate/pugjs"
 	"golang.org/x/net/html"
 )
 
@@ -21,20 +22,8 @@ type (
 )
 
 var (
-	nameRe          = regexp.MustCompile(`[a-z0-9\-]+`)
-	attributesRe    = regexp.MustCompile(`[a-z0-9]+([a-z]+)`)
-	selfClosingTags = map[string]struct{}{
-		"area":   {},
-		"base":   {},
-		"br":     {},
-		"col":    {},
-		"embed":  {},
-		"hr":     {},
-		"img":    {},
-		"input":  {},
-		"link":   {},
-		"source": {},
-	}
+	nameRe       = regexp.MustCompile(`[a-z0-9\-]+`)
+	attributesRe = regexp.MustCompile(`([a-z-:_.0-9]+)`)
 )
 
 func createTag(definition string) allowedTag {
@@ -115,7 +104,7 @@ func cleanTags(n *html.Node, allowedTags allowedTags) string {
 
 func isSelfClosingTag(n *html.Node) bool {
 	if n.Type == html.ElementNode {
-		if _, ok := selfClosingTags[n.Data]; ok {
+		if _, ok := pugjs.SelfClosingTags[n.Data]; ok {
 			return true
 		}
 	}

--- a/templatefunctions/striptags_func.go
+++ b/templatefunctions/striptags_func.go
@@ -2,42 +2,132 @@ package templatefunctions
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
+	"flamingo.me/flamingo/v3/framework/config"
 	"golang.org/x/net/html"
 )
 
 type (
-	StriptagsFunc struct{}
+	// StriptagsFunc provides template function to strip html tags
+	StriptagsFunc     struct{}
+	allowedAttributes map[string]struct{}
+	allowedTags       map[string]allowedTag
+	allowedTag        struct {
+		name       string
+		attributes allowedAttributes
+	}
 )
 
-// Func as implementation of debug method
+var (
+	nameRe          = regexp.MustCompile(`[a-z0-9\-]+`)
+	attributesRe    = regexp.MustCompile(`[a-z0-9]+([a-z]+)`)
+	selfClosingTags = map[string]struct{}{
+		"area":   {},
+		"base":   {},
+		"br":     {},
+		"col":    {},
+		"embed":  {},
+		"hr":     {},
+		"img":    {},
+		"input":  {},
+		"link":   {},
+		"source": {},
+	}
+)
+
+func createTag(definition string) allowedTag {
+	definition = strings.ToLower(definition)
+	attributes := make(allowedAttributes)
+	for _, attr := range attributesRe.FindAllString(definition, -1) {
+		attributes[attr] = struct{}{}
+	}
+
+	return allowedTag{
+		nameRe.FindString(definition),
+		attributes,
+	}
+}
+
+// Func implements the strip tags template function
 func (df StriptagsFunc) Func(ctx context.Context) interface{} {
-	return func(htmlString string) string {
+	return func(htmlString string, allowedTagsConfig ...config.Slice) string {
 		doc, err := html.ParseFragment(strings.NewReader(htmlString), nil)
 		if err != nil {
 			return ""
 		}
 
+		allowedTags := make(allowedTags)
+		if len(allowedTagsConfig) == 1 {
+			for _, item := range allowedTagsConfig[0] {
+				if definition, ok := item.(string); ok {
+					tag := createTag(definition)
+					allowedTags[tag.name] = tag
+				}
+			}
+		}
+
 		res := ""
 		for _, n := range doc {
-			res += removeTags(n)
+			res += cleanTags(n, allowedTags)
 		}
 		return res
 	}
 }
 
-func removeTags(n *html.Node) string {
+func cleanTags(n *html.Node, allowedTags allowedTags) string {
+	var allowedTag allowedTag
 	res := ""
+
+	if n.Type == html.ElementNode {
+		if tag, ok := allowedTags[n.Data]; ok {
+			allowedTag = tag
+		}
+	}
+
+	if allowedTag.name != "" {
+		res += "<"
+		res += n.Data
+		res += getAllowedAttributes(n.Attr, allowedTag.attributes)
+		if isSelfClosingTag(n) {
+			res += " /"
+		}
+		res += ">"
+	}
 
 	if n.Type == html.TextNode {
 		res += n.Data
 	}
+
 	if n.FirstChild != nil {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			res += removeTags(c)
+			res += cleanTags(c, allowedTags)
 		}
 	}
 
+	if allowedTag.name != "" && !isSelfClosingTag(n) {
+		res += "</" + n.Data + ">"
+	}
+
+	return res
+}
+
+func isSelfClosingTag(n *html.Node) bool {
+	if n.Type == html.ElementNode {
+		if _, ok := selfClosingTags[n.Data]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func getAllowedAttributes(attributes []html.Attribute, allowedAttributes allowedAttributes) string {
+	res := ""
+	for _, attr := range attributes {
+		if _, ok := allowedAttributes[attr.Key]; ok {
+			res += " " + attr.Key + "=\"" + html.EscapeString(attr.Val) + "\""
+		}
+	}
 	return res
 }

--- a/templatefunctions/striptags_func.go
+++ b/templatefunctions/striptags_func.go
@@ -2,7 +2,6 @@ package templatefunctions
 
 import (
 	"context"
-	"regexp"
 	"strings"
 
 	"flamingo.me/flamingo/v3/framework/config"
@@ -21,21 +20,25 @@ type (
 	}
 )
 
-var (
-	nameRe       = regexp.MustCompile(`[a-z0-9\-]+`)
-	attributesRe = regexp.MustCompile(`([a-z-:_.0-9]+)`)
-)
-
 func createTag(definition string) allowedTag {
 	definition = strings.ToLower(definition)
-	attributes := make(allowedAttributes)
-	for _, attr := range attributesRe.FindAllString(definition, -1) {
-		attributes[attr] = struct{}{}
+
+	if !strings.Contains(definition, "(") {
+		return allowedTag{name: definition}
+	}
+
+	split := strings.Split(definition, "(")
+	tagAttributes := make(allowedAttributes)
+	tagName := split[0]
+	allowedAttributes := strings.TrimRight(split[1], ")")
+
+	for _, attr := range strings.Split(allowedAttributes, " ") {
+		tagAttributes[attr] = struct{}{}
 	}
 
 	return allowedTag{
-		nameRe.FindString(definition),
-		attributes,
+		name:       tagName,
+		attributes: tagAttributes,
 	}
 }
 

--- a/templatefunctions/striptags_func_test.go
+++ b/templatefunctions/striptags_func_test.go
@@ -1,0 +1,52 @@
+package templatefunctions_test
+
+import (
+	"context"
+	"testing"
+
+	"flamingo.me/flamingo/v3/framework/config"
+	"flamingo.me/pugtemplate/templatefunctions"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStriptagsFunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		out         string
+		allowedTags config.Slice
+	}{
+		{"should keep plain text", "do not modify me", "do not modify me", config.Slice{}},
+		{"should keep linebreaks", "Hello\nWorld", "Hello\nWorld", config.Slice{}},
+		{"should remove tags by default", "<h1>Headline<h1> <p>Paragraph</p>", "Headline Paragraph", config.Slice{}},
+		{"should keep defined tags", "<h1>Headline</h1>", "<h1>Headline</h1>", config.Slice{"h1", "h2"}},
+		{"should handle self-closing tags", "<h1>Hello<br />World</h1>", "<h1>Hello<br />World</h1>", config.Slice{"h1", "br"}},
+		{
+			"should remove non whitelisted attributes",
+			"<h1 style=\"font-size: 500px\">Keep me</h1><script src=\"http://miner.tld/x.js\">",
+			"<h1>Keep me</h1>",
+			config.Slice{"h1"},
+		},
+		{
+			"should keep whitelisted attributes",
+			"<p>I'm a paragraph containing a <a href=\"http://tld.com\" style=\"font-size:100px\">link</a></p>",
+			"<p>I'm a paragraph containing a <a href=\"http://tld.com\">link</a></p>",
+			config.Slice{"p", "a(href)"},
+		},
+		{
+			"should keep multiple whitelisted attributes",
+			"<a href=\"http://domain.tld\" target=\"_blank\" rel=\"nofollow\">Link with target</a>",
+			"<a href=\"http://domain.tld\" target=\"_blank\">Link with target</a>",
+			config.Slice{"a(href target)"},
+		},
+	}
+
+	var stripTagsFunc = new(templatefunctions.StriptagsFunc)
+	stripTags := stripTagsFunc.Func(context.Background()).(func(htmlString string, allowedTagsConfig ...config.Slice) string)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, stripTags(tt.in, tt.allowedTags), tt.name)
+		})
+	}
+}

--- a/templatefunctions/striptags_func_test.go
+++ b/templatefunctions/striptags_func_test.go
@@ -61,7 +61,13 @@ func TestStriptagsFunc(t *testing.T) {
 			"something i found in real life",
 			`<div class="miniCart" :class="{miniCartWishlistVisible: itemCount}"></div>`,
 			`<div class="miniCart" :class="{miniCartWishlistVisible: itemCount}"></div>`,
-			config.Slice{"div(class, :class)"},
+			config.Slice{"div(class :class)"},
+		},
+		{
+			"attributes without value",
+			`<input disabled name="remove-me"/>`,
+			`<input disabled />`,
+			config.Slice{"input(disabled)"},
 		},
 	}
 

--- a/templatefunctions/striptags_func_test.go
+++ b/templatefunctions/striptags_func_test.go
@@ -39,6 +39,30 @@ func TestStriptagsFunc(t *testing.T) {
 			"<a href=\"http://domain.tld\" target=\"_blank\">Link with target</a>",
 			config.Slice{"a(href target)"},
 		},
+		{
+			"attribute naming",
+			`<div data-test:foo.bar="a">b</div>`,
+			`<div data-test:foo.bar="a">b</div>`,
+			config.Slice{"div(data-test:foo.bar)"},
+		},
+		{
+			"vue.js attr",
+			`<div v="menuLevel0ActiveIndex === 0 ? &#34;true&#34; : &#34;false&#34;">b</div>`,
+			`<div v="menuLevel0ActiveIndex === 0 ? &#34;true&#34; : &#34;false&#34;">b</div>`,
+			config.Slice{"div(v)"},
+		},
+		{
+			"vue.js complete",
+			`<div v-bind:aria-expanded="menuLevel0ActiveIndex === 0 ? &#34;true&#34; : &#34;false&#34;">b</div>`,
+			`<div v-bind:aria-expanded="menuLevel0ActiveIndex === 0 ? &#34;true&#34; : &#34;false&#34;">b</div>`,
+			config.Slice{"div(v-bind:aria-expanded)"},
+		},
+		{
+			"something i found in real life",
+			`<div class="miniCart" :class="{miniCartWishlistVisible: itemCount}"></div>`,
+			`<div class="miniCart" :class="{miniCartWishlistVisible: itemCount}"></div>`,
+			config.Slice{"div(class, :class)"},
+		},
 	}
 
 	var stripTagsFunc = new(templatefunctions.StriptagsFunc)


### PR DESCRIPTION
This allows developers to output html safely as it will only output specific tags and their whitelisted attributes.

As an example you can create a new list in `config.yml` and use it in your template with the config() function:

```yml
allowedTags:
 - "h2"
 - "h3"
 - "p"
 - "a(href target rel)"
 - "img(src alt)"
```

```pug
.productDescription = stripTags(description, config('allowedTags'))
```