### PR TITLE
add panicOrDebug method using sideeffects to get logger and config

### DIFF
--- a/pugjs/engine.go
+++ b/pugjs/engine.go
@@ -80,9 +80,8 @@ var (
 	rt             = stats.Int64("flamingo/pugtemplate/render", "pugtemplate render times", stats.UnitMilliseconds)
 	templateKey, _ = tag.NewKey("template")
 
-	debugMode = false
+	debugMode      = false
 	loggerInstance flamingo.Logger
-
 )
 
 func init() {
@@ -90,7 +89,14 @@ func init() {
 }
 
 // NewEngine constructor
-func NewEngine() *Engine {
+func NewEngine(debugsetup *struct {
+	Debug  bool            `inject:"config:debug.mode"`
+	Logger flamingo.Logger `inject:""`
+}) *Engine {
+	if debugsetup != nil {
+		setLoggerInfos(debugsetup.Logger, debugsetup.Debug)
+	}
+
 	return &Engine{
 		RWMutex:      new(sync.RWMutex),
 		TemplateCode: make(map[string]string),
@@ -235,7 +241,6 @@ func (e *Engine) RenderPartials(ctx context.Context, templateName string, data i
 
 // Render via html/pug_template
 func (e *Engine) Render(ctx context.Context, templateName string, data interface{}) (io.Reader, error) {
-	setLoggerInfos(e.Logger,e.Debug)
 	ctx, span := trace.StartSpan(ctx, "pug/render")
 	defer span.End()
 

--- a/pugjs/types.go
+++ b/pugjs/types.go
@@ -176,7 +176,8 @@ func convert(in interface{}) Object {
 		return Nil{}
 	}
 
-	panic(fmt.Sprintf("Cannot convert %#v %T %s %s", val, val, val.Type(), val.Kind()))
+	panicOrError(fmt.Sprintf("Cannot convert %#v %T %s %s", val, val, val.Type(), val.Kind()))
+	return Nil{}
 }
 
 // Func type
@@ -267,7 +268,8 @@ func (a *Array) Member(name string) Object {
 		return &Func{fnc: reflect.ValueOf(a.Sort)}
 	}
 
-	panic("field " + name + " not found")
+	panicOrError("field '" + name + "' not found on pugjs Array")
+	return Nil{}
 }
 
 // Splice an array
@@ -476,7 +478,8 @@ func (m *Map) String() string {
 	}
 	b, err := m.MarshalJSON()
 	if err != nil {
-		panic(err)
+		panicOrError(err)
+		return ""
 	}
 	return string(b)
 }

--- a/templatefunctions/url_func.go
+++ b/templatefunctions/url_func.go
@@ -2,6 +2,7 @@ package templatefunctions
 
 import (
 	"context"
+	"flamingo.me/flamingo/v3/framework/flamingo"
 	"html/template"
 	"net/url"
 
@@ -13,6 +14,8 @@ type (
 	// URLFunc allows templates to access the routers `URL` helper method
 	URLFunc struct {
 		Router *web.Router `inject:""`
+		Logger flamingo.Logger `inject:""`
+		DebugMode bool `inject:"config:debug.mode"`
 	}
 )
 
@@ -50,7 +53,11 @@ func (u *URLFunc) Func(ctx context.Context) interface{} {
 				}
 			}
 		}
-		url, _ := u.Router.URL(where, p)
+		url, err := u.Router.Relative(where, p)
+		if err != nil {
+			u.panicOrError(err)
+			return ""
+		}
 		query := url.Query()
 		for k, v := range q {
 			for _, i := range v {
@@ -61,3 +68,13 @@ func (u *URLFunc) Func(ctx context.Context) interface{} {
 		return template.URL(url.String())
 	}
 }
+
+
+func (u *URLFunc)  panicOrError(v interface{}) {
+	if u.DebugMode {
+		panic(v)
+	} else {
+		u.Logger.WithField(flamingo.LogKeyModule,"pugtemplate").WithField(flamingo.LogKeyCategory,"urltemplatefunc").Error(v)
+	}
+}
+

--- a/templatefunctions/url_func.go
+++ b/templatefunctions/url_func.go
@@ -13,9 +13,9 @@ import (
 type (
 	// URLFunc allows templates to access the routers `URL` helper method
 	URLFunc struct {
-		Router *web.Router `inject:""`
-		Logger flamingo.Logger `inject:""`
-		DebugMode bool `inject:"config:debug.mode"`
+		Router    *web.Router     `inject:""`
+		Logger    flamingo.Logger `inject:""`
+		DebugMode bool            `inject:"config:debug.mode"`
 	}
 )
 
@@ -69,12 +69,10 @@ func (u *URLFunc) Func(ctx context.Context) interface{} {
 	}
 }
 
-
-func (u *URLFunc)  panicOrError(v interface{}) {
+func (u *URLFunc) panicOrError(v interface{}) {
 	if u.DebugMode {
 		panic(v)
 	} else {
-		u.Logger.WithField(flamingo.LogKeyModule,"pugtemplate").WithField(flamingo.LogKeyCategory,"urltemplatefunc").Error(v)
+		u.Logger.WithField(flamingo.LogKeyModule, "pugtemplate").WithField(flamingo.LogKeyCategory, "urltemplatefunc").Error(v)
 	}
 }
-


### PR DESCRIPTION
Problem:

Bad coded pug templates can result in runtime errors.
E.g. when acessing an Array member that does not (always) exists.

This should not result in hard errors in production mode.
