### PR TITLE
fix usage of pageKey in module.go

### DIFF
--- a/module.go
+++ b/module.go
@@ -94,7 +94,7 @@ func (r *routes) Routes(registry *web.RouterRegistry) {
 	registry.Route("/static/*n", "_static")
 
 	registry.HandleData("page.template", func(ctx context.Context, _ *web.Request, _ web.RequestParams) interface{} {
-		return ctx.Value("page.template")
+		return ctx.Value(pugjs.PageKey)
 	})
 
 	registry.Route("/assets/*f", "_pugtemplate.assets")

--- a/pugjs/engine.go
+++ b/pugjs/engine.go
@@ -72,6 +72,7 @@ type (
 )
 
 const (
+	// PageKey is used as constant in WithValue function and in module.go
 	PageKey key = "page.template"
 )
 

--- a/pugjs/engine.go
+++ b/pugjs/engine.go
@@ -72,7 +72,7 @@ type (
 )
 
 const (
-	pageKey key = "page.template"
+	PageKey key = "page.template"
 )
 
 var (
@@ -250,7 +250,7 @@ func (e *Engine) Render(ctx context.Context, templateName string, data interface
 	if len(p) >= 2 && p[len(p)-2] != page {
 		page = p[len(p)-2] + p[len(p)-1]
 	}
-	ctx = context.WithValue(ctx, pageKey, "page"+page)
+	ctx = context.WithValue(ctx, PageKey, "page"+page)
 
 	// recompile, make sure to fully load only once!
 	if atomic.LoadInt32(&e.templatesLoaded) == 0 && !e.Debug {


### PR DESCRIPTION
DataHandler must use the same constant that is used in engine.go, comparing the string with the type key did not work