### PR TITLE
Allow JSON.parse() to convert strings of arrays

### DIFF
--- a/templatefunctions/js_json.go
+++ b/templatefunctions/js_json.go
@@ -33,7 +33,7 @@ func (j JSON) Stringify(x interface{}) string {
 
 // Parse Stringify parses a string and returns an object
 func (j JSON) Parse(x string) pugjs.Object {
-	m := make(map[string]interface{})
+	var m interface{}
 	err := json.Unmarshal([]byte(x), &m)
 	if err != nil {
 		panic(err)

--- a/templatefunctions/js_json_test.go
+++ b/templatefunctions/js_json_test.go
@@ -18,9 +18,11 @@ func TestJsJSON(t *testing.T) {
 
 func TestJSON_Parse(t *testing.T) {
 	var jsJSON flamingo.TemplateFunc = new(JsJSON)
-
 	json := jsJSON.Func(context.Background()).(func() JSON)()
-	result := json.Parse(`{"foo":123}`)
 
-	assert.Implements(t, (*pugjs.Object)(nil), result)
+	obj := json.Parse(`{"foo":123}`)
+	assert.Implements(t, (*pugjs.Object)(nil), obj)
+
+	arr := json.Parse(`["testing123", 123, {"an": "object"}]`)
+	assert.Implements(t, (*pugjs.Object)(nil), arr)
 }


### PR DESCRIPTION
JSON.parse() can convert e.g. '["testing123"]' into a JavaScript array.
This is will do the same in Go.