### PR TITLE
use json.Marshal to create serialized strings

### DIFF
--- a/pugjs/types.go
+++ b/pugjs/types.go
@@ -202,14 +202,12 @@ var AllowDeep = true
 
 // MarshalJSON implementation
 func (f *Func) MarshalJSON() ([]byte, error) {
-	if f.fnc.Type().NumIn() == 0 && f.fnc.Type().NumOut() == 1 {
-		if AllowDeep {
-			return json.Marshal(convert(f.fnc.Call(nil)[0]))
-		}
-		// return function name as string, to avoid circular calls
-		return json.Marshal(f.fnc.String())
+	if f.fnc.Type().NumIn() == 0 && f.fnc.Type().NumOut() == 1 && AllowDeep {
+		return json.Marshal(convert(f.fnc.Call(nil)[0]))
 	}
-	return []byte(`"` + f.String() + `"`), nil
+
+	// return function name as string, to avoid circular calls
+	return json.Marshal(f.String())
 }
 
 // Array type


### PR DESCRIPTION
Before it was possible to get unescaped double quotes in the string, which results in faulty JSON.