### PR TITLE
Verify stripTags filters escaped script tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module flamingo.me/pugtemplate
 require (
 	flamingo.me/dingo v0.1.6
 	flamingo.me/flamingo/v3 v3.0.1
-	github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835 // indirect
 	github.com/go-test/deep v1.0.1
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -14,7 +13,6 @@ require (
 	go.opencensus.io v0.20.2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375
 	gopkg.in/sourcemap.v1 v1.0.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -108,10 +108,6 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190209105433-f8d8b3f739bd h1:pi7bGw6n4tfgHQtWDxJBBLYVdFr1GlfQEsDOyCDDFMM=
 github.com/prometheus/procfs v0.0.0-20190209105433-f8d8b3f739bd/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d h1:1VUlQbCfkoSGv7qP7Y+ro3ap1P1pPZxgdGVqiTVy5C4=
-github.com/robertkrimen/otto v0.0.0-20180617131154-15f95af6e78d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
-github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1KO6SAfUX918c+Tab0+tGAM/mtdlUyA=
-github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
@@ -192,8 +188,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375 h1:hPki/oSSWOLiI9Gc9jyIoj33O3j29fUc9PlLha2yDj0=
-gopkg.in/readline.v1 v1.0.0-20160726135117-62c6fe619375/go.mod h1:lNEQeAhU009zbRxng+XOj5ITVgY24WcbNnQopyfKoYQ=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/square/go-jose.v2 v2.1.9/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/templatefunctions/striptags_func.go
+++ b/templatefunctions/striptags_func.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	"flamingo.me/flamingo/v3/framework/config"
-	"flamingo.me/pugtemplate/pugjs"
 	"golang.org/x/net/html"
+
+	"flamingo.me/pugtemplate/pugjs"
 )
 
 type (
@@ -89,7 +90,12 @@ func cleanTags(n *html.Node, allowedTags allowedTags) string {
 	}
 
 	if n.Type == html.TextNode {
-		res += n.Data
+		// We assume the body of a text node is valid fully escaped.
+		//
+		// In case a pre-escaped input arrives here, it would have been unescaped
+		// by html.Parse and would end up here as unrecognized HTML tags.
+		// Escaping mitigates unwanted HTML (like script).
+		res += html.EscapeString(n.Data)
 	}
 
 	if n.FirstChild != nil {

--- a/templatefunctions/striptags_func_test.go
+++ b/templatefunctions/striptags_func_test.go
@@ -30,7 +30,7 @@ func TestStriptagsFunc(t *testing.T) {
 		{
 			"should keep whitelisted attributes",
 			"<p>I'm a paragraph containing a <a href=\"http://tld.com\" style=\"font-size:100px\">link</a></p>",
-			"<p>I'm a paragraph containing a <a href=\"http://tld.com\">link</a></p>",
+			"<p>I&#39;m a paragraph containing a <a href=\"http://tld.com\">link</a></p>",
 			config.Slice{"p", "a(href)"},
 		},
 		{
@@ -68,6 +68,30 @@ func TestStriptagsFunc(t *testing.T) {
 			`<input disabled name="remove-me"/>`,
 			`<input disabled />`,
 			config.Slice{"input(disabled)"},
+		},
+		{
+			name:        "should filter script tag with only simple html tags allowed",
+			in:          "<script>alert('security!');</script>",
+			out:         "alert(&#39;security!&#39;);",
+			allowedTags: config.Slice{"p"},
+		},
+		{
+			name:        "should filter script tag with escaped input",
+			in:          "<p>&lt;script&gt;alert('security');&lt;/script&gt;</p>",
+			out:         "<p>&lt;script&gt;alert(&#39;security&#39;);&lt;/script&gt;</p>",
+			allowedTags: config.Slice{"p"},
+		},
+		{
+			name:        "should filter script tag",
+			in:          "<p><script>alert('security')</script></p>",
+			out:         "<p>alert(&#39;security&#39;)</p>",
+			allowedTags: config.Slice{"p"},
+		},
+		{
+			name:        "should filter illegal tag which is escaped and surrounded by other tags",
+			in:          "<p><b>test</b>&lt;script&gt;alert('security');&lt;/script&gt;<b>test</b></p>",
+			out:         "<p><b>test</b>&lt;script&gt;alert(&#39;security&#39;);&lt;/script&gt;<b>test</b></p>",
+			allowedTags: config.Slice{"p", "b"},
 		},
 	}
 

--- a/templatefunctions/striptags_func_test.go
+++ b/templatefunctions/striptags_func_test.go
@@ -76,6 +76,12 @@ func TestStriptagsFunc(t *testing.T) {
 			allowedTags: config.Slice{"p"},
 		},
 		{
+			name:        "should not filter script tag",
+			in:          "<script>alert('security!');</script>",
+			out:         "<script>alert(&#39;security!&#39;);</script>",
+			allowedTags: config.Slice{"p", "script"},
+		},
+		{
 			name:        "should filter script tag with escaped input",
 			in:          "<p>&lt;script&gt;alert('security');&lt;/script&gt;</p>",
 			out:         "<p>&lt;script&gt;alert(&#39;security&#39;);&lt;/script&gt;</p>",


### PR DESCRIPTION
This changes `stripTags` to always escape the body of text node HTML tags.

Previously, `stripTags` made it possible to inject executable javascript when passing in escaped HTML. The reason for this is golang's HTML Tokenizer, which states:

> Data is unescaped for all Tokens (it looks like "a<b" rather than "a\&lt;b").