### PR TITLE
Make Nil attribute's value falsy

### DIFF
--- a/pugjs/runtime.go
+++ b/pugjs/runtime.go
@@ -153,10 +153,10 @@ var funcmap = FuncMap{
 		if v, ok := v.(bool); ok {
 			return []Attribute{{Name: k, BoolVal: &v}}
 		}
-		// if _, ok := v.(Nil); ok {
-		// 	b := false
-		// 	return []Attribute{{Name: k, BoolVal: &b}}
-		// }
+		if _, ok := v.(Nil); ok {
+			b := false
+			return []Attribute{{Name: k, BoolVal: &b}}
+		}
 		if v, ok := v.(Object); ok {
 			return []Attribute{{Name: k, Val: JavaScriptExpression(v.String()), MustEscape: e}}
 		}


### PR DESCRIPTION
This used to be only commented but for info here is a some context

**Problem**
```
mixin test(checked)
  input(type='checkbox' checked=checked)

+test()
```
Renders great in JS but not in Flamingo.

```
JS: <input type="checkbox"> <-- unchecked
Flamingo: <input type="checkbox" checked=""> <-- checked
```
Unfortunately this can produce unexpected results in many cases.

**Current Workaround**
The easiest fix was to just booleanize the value but other cases need more complex workarounds.
```
mixin test(checked)
  - checked = !!checked
  input(type='checkbox' checked=checked)

+test()
```

In JS the variable resolves to undefined which ends up in not declaring the attribute rather than behaving like an empty string.

**Desired result**
https://codepen.io/yesman82/pen/OEGPWL?editors=1001
```
mixin test(checked)
  input(type='checkbox' checked=checked)
  block
  br

+test(true) true
+test(0) 0
+test("") ""
+test(undefined) undefined
+test(null) null
+test(false) false
+test()
```